### PR TITLE
Fix mobile header margins

### DIFF
--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -30,7 +30,7 @@
 
 		header
 		{
-			margin: 0 0 1em 0;
+			margin: 0 0 2.5em 0;
 		}
 		
 		footer


### PR DESCRIPTION
This adds enough bottom margin so the header isn't cut off by the previews.

### Broken
![headermargin](https://cloud.githubusercontent.com/assets/6006148/14787249/344c17b2-0ac8-11e6-87a2-3dbe89566615.PNG)

### Good
![good](https://cloud.githubusercontent.com/assets/6006148/14787256/39493c4a-0ac8-11e6-9a89-658b6f1c0388.PNG)