### PR TITLE
Adding active anchor link on the NativeScriptSnacks web site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NativeScript Snacks
 
-The gh-pages branch of this repo hosts [NativeScriptSnacks.com](nativeScriptsnacks.com), a website with short, snack-sized video content that helps users learn more at Telerik NativeScript.
+The gh-pages branch of this repo hosts [NativeScriptSnacks.com](https://nativeScriptsnacks.com), a website with short, snack-sized video content that helps users learn more at Telerik NativeScript.
 
 If you'd like to contribute content, please use the 'contribute' link on the site.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NativeScript Snacks
 
-The gh-pages branch of this repo hosts [NativeScriptSnacks.com](https://nativeScriptsnacks.com), a website with short, snack-sized video content that helps users learn more at Telerik NativeScript.
+The gh-pages branch of this repo hosts [NativeScriptSnacks.com](http://www.nativeScriptsnacks.com), a website with short, snack-sized video content that helps users learn more at Telerik NativeScript.
 
 If you'd like to contribute content, please use the 'contribute' link on the site.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NativeScript Snacks
 
-The gh-pages branch of this repo hosts NativeScriptSnacks.com, a website with short, snack-sized video content that helps users learn more at Telerik NativeScript.
+The gh-pages branch of this repo hosts [NativeScriptSnacks.com](nativeScriptsnacks.com), a website with short, snack-sized video content that helps users learn more at Telerik NativeScript.
 
 If you'd like to contribute content, please use the 'contribute' link on the site.
 


### PR DESCRIPTION
Quickly jump to the website, if you find yourself in the master branch of the repo.